### PR TITLE
Change config delimiter reference

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -52,7 +52,7 @@ class Util implements TaggingUtility
 		$str = mb_convert_encoding((string)$str, 'UTF-8');
 	
 		$options = array(
-			'delimiter' => config('taggable.delimiter', '-'),
+			'delimiter' => config('tagging.delimiter', '-'),
 			'limit' => '255',
 			'lowercase' => true,
 			'replacements' => array(),


### PR DESCRIPTION
Util was using `taggable.delimiter` to format slugs. The name of the config is `tagging`, so updated to `tagging.delimiter`